### PR TITLE
Update type hints

### DIFF
--- a/graphchem/preprocessing/features.py
+++ b/graphchem/preprocessing/features.py
@@ -7,7 +7,7 @@ import torch
 
 
 def get_ring_size(
-        obj: Union[rdkit.Chem.Atom, rdkit.Chem.Bond],
+        obj: Union["rdkit.Chem.Atom", "rdkit.Chem.Bond"],
         max_size: Optional[int] = 12
      ) -> int:
     """
@@ -35,7 +35,7 @@ def get_ring_size(
     return max_size
 
 
-def atom_to_str(atom: rdkit.Chem.Atom) -> str:
+def atom_to_str(atom: "rdkit.Chem.Atom") -> str:
     """
     Convert an RDKit Atom object to a string representation.
 
@@ -82,7 +82,7 @@ def atom_to_str(atom: rdkit.Chem.Atom) -> str:
     ))
 
 
-def bond_to_str(bond: rdkit.Chem.Bond) -> str:
+def bond_to_str(bond: "rdkit.Chem.Bond") -> str:
     """
     Convert an RDKit Bond object to a string representation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include-package-data = true
 
 [project]
 name = "graphchem"
-version = "2.3.1"
+version = "2.3.2"
 authors = [
     { name="Travis Kessler", email="travis.j.kessler@gmail.com" },
 ]


### PR DESCRIPTION
Add quotes to RDKit atom/bond object type hints, plays nicer with RDKit imports